### PR TITLE
Max depth

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -121,6 +121,8 @@
 /**
  * Style
  */
+    "max-depth": [2, 3],             // http://eslint.org/docs/rules/max-depth
+    "max-nested-callbacks": [2, 2],  // http://eslint.org/docs/rules/max-nested-callbacks
     "indent": [2, 2],                // http://eslint.org/docs/rules/
     "brace-style": [2,               // http://eslint.org/docs/rules/brace-style
       "1tbs", {


### PR DESCRIPTION
Limit the max nested blocks and callbacks to sane values:

Blocks (max-depth)

```
function foo() {
  for (var i = 0; i < 1; i += 1;) {
    if (true) {
      if (true) {
        // inside 3rd block, too deep
      }
    }
  }
}
```

Callbacks (max-call-backs)

```
foo(function () {
  bar(function () {
    baz(function() {
      // inside a 3rd callback, too deep
    });
  });
});
```
### Note

If we're open to it, I'd love to limit callbacks to 2 deep.
